### PR TITLE
feat: test contracts for calling a generic function stored in a struct

### DIFF
--- a/contracts/BalanceTest.sol
+++ b/contracts/BalanceTest.sol
@@ -1,0 +1,20 @@
+pragma solidity 0.7.4;
+
+contract BalanceTest {
+
+    constructor () public{
+
+    }
+
+    function balanceOfAddress(address account) public returns (uint256) {
+        return 100;
+    }
+
+    function balanceOfInt(uint256 number) public returns (uint256) {
+        return 101;
+    }
+
+    function balanceOfMulti(address account, uint256 number, bytes32 word) public returns (uint256) {
+        return 102;
+    }
+}

--- a/contracts/GenericFunctionTest.sol
+++ b/contracts/GenericFunctionTest.sol
@@ -1,0 +1,78 @@
+pragma solidity 0.7.4;
+
+contract GenericFunctionTest {
+
+    constructor (address balanceContractAddress) public{
+        address balance = balanceContractAddress;
+
+        bytes4 funnctionSigAddress = bytes4(keccak256("balanceOfAddress(address)"));
+        bytes4 funnctionSigInt = bytes4(keccak256("balanceOfInt(uint256)"));
+        bytes4 funnctionSigMulti = bytes4(keccak256("balanceOfMulti(address,uint256,bytes32)"));
+
+        bytes32[5] memory functionParametersNoKeyWord;
+        functionParametersNoKeyWord[0]= bytes32(uint256(msg.sender));
+        functionParametersNoKeyWord[1]= bytes32(uint256(500));
+        functionParametersNoKeyWord[2]= bytes32("hello");
+
+        bytes32[5] memory functionParametersKeyWord;
+        functionParametersKeyWord[0]= bytes32("msg.sender");
+        functionParametersKeyWord[1]= bytes32(uint256(400));
+        functionParametersKeyWord[2]= bytes32("hello");
+
+        // basic call test  w/ one address param
+
+        // commented out to not exceed stack limit w/ local vars
+        // (bool successAddress, bytes memory resultAddress) = balance.call(abi.encodePacked(funnctionSigAddress, functionParametersNoKeyWord[0]));
+        // require(successAddress == true, "Address Transaction Unsuccessful");
+        // require(toUint256(resultAddress) == 100, "Transaction Return Not Expected");
+
+        // basic call test  w/ one address param
+
+        // commented out to not exceed stack limit w/ local vars
+        // (bool successInt, bytes memory resultInt) = balance.call(abi.encodePacked(funnctionSigInt, functionParametersNoKeyWord[1]));
+        // require(successInt == true, "Int Transaction Unsuccessful");
+        // require(toUint256(resultInt) == 101, "Transaction Return Not Expected");
+
+        // call with multiple params
+
+        (bool successMulti, bytes memory resultMulti) = balance.call(abi.encodePacked(funnctionSigMulti, functionParametersNoKeyWord[0], functionParametersNoKeyWord[1], functionParametersNoKeyWord[2]));
+        require(successMulti == true, "Multi Transaction Unsuccessful");
+        require(toUint256(resultMulti) == 102, "Transaction Multi Not Expected");
+
+        // replace keywords w/o key keywords ( no replacements )
+
+        for (uint i = 0; i < functionParametersNoKeyWord.length; i++) {
+            if ( functionParametersNoKeyWord[i] == bytes32("msg.sender") ){
+                functionParametersNoKeyWord[i] =  bytes32(uint256(msg.sender));
+            }
+        }
+        (bool successMultiNoReplace, bytes memory resultMultiNoReplace) = balance.call(abi.encodePacked(funnctionSigMulti, functionParametersNoKeyWord[0], functionParametersNoKeyWord[1], functionParametersNoKeyWord[2]));
+        require(successMultiNoReplace == true, "Multi No Replace Transaction Unsuccessful");
+        require(toUint256(resultMultiNoReplace) == 102, "Transaction Multi No Replace Not Expected");
+
+        // replace keywords with keywords (one replacement)
+        for (uint i = 0; i < functionParametersKeyWord.length; i++) {
+            if ( functionParametersKeyWord[i] == bytes32("msg.sender") ){
+                functionParametersKeyWord[i] =  bytes32(uint256(msg.sender));
+            }
+        }
+        (bool successMultiReplace, bytes memory resultMultiReplace) = balance.call(abi.encodePacked(funnctionSigMulti, functionParametersKeyWord[0], functionParametersKeyWord[1], functionParametersKeyWord[2]));
+        require(successMultiReplace == true, "Multi With Replace Transaction Unsuccessful");
+        require(toUint256(resultMultiReplace) == 102, "Transaction Result Multi With Replace Not Expected");
+
+
+        // used replaced data with an extra arguements (this allows you to call a function expecting 1 arg, but sending 5)
+        // is more gas, but makes like easier than trying to figure out the  # of params to send
+        bytes memory extendedCallData = abi.encodePacked(funnctionSigMulti, functionParametersKeyWord[0], functionParametersKeyWord[1], functionParametersKeyWord[2], functionParametersKeyWord[3], functionParametersKeyWord[4]);
+        (bool extendedCallDataSuccess, bytes memory extendedCallDataResult) = balance.call(extendedCallData);
+        require(extendedCallDataSuccess == true, "Multi With Replace Transaction Unsuccessful");
+        require(toUint256(extendedCallDataResult) == 102, "Transaction Result Multi With Replace Not Expected");
+
+    }
+
+    function toUint256(bytes memory _bytes) internal pure returns (uint256 value) {
+        assembly {
+            value := mload(add(_bytes, 0x20))
+        }
+    }
+}

--- a/test/genericFunctions.js
+++ b/test/genericFunctions.js
@@ -1,0 +1,21 @@
+const { expect, use } = require("chai");
+const { waffle, ethers } = require("hardhat");
+
+const GenericFunctionTest = require("../artifacts/contracts/GenericFunctionTest.sol/GenericFunctionTest.json");
+const BalanceTest = require("../artifacts/contracts/BalanceTest.sol/BalanceTest.json");
+
+const { deployContract, provider, solidity } = waffle;
+
+use(solidity);
+
+describe("Orca Tests", () => {
+  const [admin, host, member, other] = provider.getWallets();
+
+  let genericFunctionTest;
+  let balanceTest;
+
+  it("should deploy contracts", async () => {
+    balanceTest = await deployContract(admin, BalanceTest);
+    genericFunctionTest = await deployContract(admin, GenericFunctionTest, [balanceTest.address]);
+  });
+});


### PR DESCRIPTION
Run `npm run test` and confirm the new test script passes. There are require statements in the constructor of the test contract -- if it deploys, the functionality is working.

Adding two contracts and a test to show that if we have a Rule struct with a 
{
address contractAddress,
bytes4 functionSignature,
bytes32[5] functionParam,
}

we can pretty much arbitrarily call any function on any contract, and if we use key words, we can swap out parameters at execution. 

key assumptions, only using 5 paramters - tested parameter types are uint256, address, bytes32. Parameters larger than 32 bytes won't work. parameters smaller than 32 bytes may work, but should be tested.

and interesting piece is that you can encode an arbitrary number of parameters in your `call`, but only the parameters the contract is expecting will be used. This saves needing to figure out how many params to send, or trying to encode and then combine only the necessary variables, which I think would require assembly