### PR TITLE
feat:action-proposal

### DIFF
--- a/contracts/OrcaVoteManager.sol
+++ b/contracts/OrcaVoteManager.sol
@@ -57,7 +57,11 @@ contract OrcaVoteManager {
         uint256 minQuorum
     );
 
-    event CreateRuleProposal(uint256 proposalId, uint256 podId, address proposer);
+    event CreateRuleProposal(
+        uint256 proposalId,
+        uint256 podId,
+        address proposer
+    );
 
     event CreateActionProposal(
         uint256 proposalId,
@@ -204,8 +208,8 @@ contract OrcaVoteManager {
 
         voteProposalByPod[_podId] = currentProposal;
 
-
-        ActionProposal memory actionProposal = ActionProposal(_to, _value, _data);
+        ActionProposal memory actionProposal =
+            ActionProposal(_to, _value, _data);
 
         emit CreateActionProposal(
             voteProposalByPod[_podId].proposalId,


### PR DESCRIPTION
- [X]  Create Pod Per Group
- [X]  Create Proposed Action
- [X]  Vote (maybe the same)
- [ ]  ExecuteAction

This is a bit messy we should consider the best re-factor - what should live where and the security concerns around that

Both rule and action proposals are managed in the same `PodVoteProposal`. You can only have one proposal (no matter if it's an action or rule proposal) at one time. All Action Structs are managed within the voting manager.