### PR TITLE
feat: add OrcaProtocol as controller to all contracts

### DIFF
--- a/contracts/OrcaProtocol.sol
+++ b/contracts/OrcaProtocol.sol
@@ -110,6 +110,13 @@ contract OrcaProtocol {
 
     }
 
+    function vote(uint256 _podId, bool _yesOrNo) public {
+        
+        require(powerBank.getPower(msg.sender, _podId) != 0 ,"User lacks power");
+
+        voteManager.vote(_podId, _yesOrNo, msg.sender);
+    }
+
     function finalizeProposal(uint _podId) public{
         // proposalType 0 = rule, 1 = action
         (bool didPass, uint256 proposalType, uint256 executableId) = voteManager.finalizeProposal(_podId);

--- a/contracts/PowerBank.sol
+++ b/contracts/PowerBank.sol
@@ -33,6 +33,8 @@ contract PowerBank is ERC1155Holder {
     using SafeMath for uint256;
     using Address for address;
 
+    address controller;
+
     PowerToken public powerToken;
     // Maps podIds to pods
     mapping(uint256 => Pod) pods;
@@ -43,21 +45,16 @@ contract PowerBank is ERC1155Holder {
         uint256 totalSupply;
     }
 
-    // probably a better way to manage  this
-    // dependent on how we are managing contract deployment
-    modifier onlyProtocol {
-        // require(
-        //     // TODO: Should these be the same modifier?
-        //     (msg.sender == deployer) || (msg.sender == votingManager),
-        //     "Only OrcaProtocol can call this function."
-        // );
-        _;
-    }
-
     constructor(address _powerToken) public {
         powerToken = PowerToken(_powerToken);
         // approve admin to transfer tokens on behalf of the powerbank
         powerToken.setApprovalForAll(msg.sender,true);
+        controller = msg.sender;
+    }
+
+    function updateController(address _controller) public {
+        require(controller == msg.sender, "!controller");
+        controller = _controller;
     }
 
     /**
@@ -68,6 +65,7 @@ contract PowerBank is ERC1155Holder {
         uint256 _podId,
         uint256 _totalSupply
     ) public {
+        require(controller == msg.sender, "!controller");
         // Using totalSupply to add potential for people to claim "dead" podIds.
         require(pods[_podId].totalSupply == 0, "Pod already exists");
 
@@ -82,7 +80,7 @@ contract PowerBank is ERC1155Holder {
     }
 
     function claimMembership(address _user, uint256 _podId) public {
-        // only protocol
+        require(controller == msg.sender, "!controller");
         require(powerToken.balanceOf(address(this), _podId) >= 1, "No Memberships Availible");
 
         require(
@@ -105,10 +103,8 @@ contract PowerBank is ERC1155Holder {
 
     // TODO: We probably need some way for someone to give up their own token.
     // I think this is currently impossible with the way PowerBank is built
-
-    // // add modifier for only OrcaProtocol
     function retractMembership(uint256 _podId, address _member) public {
-
+        require(controller == msg.sender, "!controller");
         powerToken.safeTransferFrom(
             _member,
             address(this),

--- a/contracts/RuleManager.sol
+++ b/contracts/RuleManager.sol
@@ -5,6 +5,8 @@ pragma solidity 0.7.4;
 // This contract manages the membership rules
 // it is responsible for storing pod rules, and validating rule compliance
 
+// TODO: ADD STATIC CALLS
+
 contract RuleManager {
     // Rules
     struct Rule {
@@ -16,6 +18,7 @@ contract RuleManager {
         bool isFinalized;
     }
 
+    address controller;
     mapping(uint256 => Rule) public rulesByPod;
 
     event UpdateRule(
@@ -27,6 +30,15 @@ contract RuleManager {
         uint256 comparisonValue
     );
 
+    constructor () {
+        controller = msg.sender;
+    }
+
+    function updateController(address _controller) public {
+        require(controller == msg.sender, "!controller");
+        controller = _controller;
+    }
+
     function setPodRule(
         uint256 _podId,
         address _contractAddress,
@@ -35,6 +47,7 @@ contract RuleManager {
         uint256 _comparisonLogic,
         uint256 _comparisonValue
     ) public {
+        require(controller == msg.sender, "!controller");
         rulesByPod[_podId] = Rule(
             _contractAddress,
             _functionSignature,
@@ -46,6 +59,7 @@ contract RuleManager {
     }
 
     function finalizeRule(uint256 _podId) public {
+        require(controller == msg.sender, "!controller");
         rulesByPod[_podId].isFinalized = true;
 
         emit UpdateRule(
@@ -62,6 +76,7 @@ contract RuleManager {
         public
         returns (bool)
     {
+        require(controller == msg.sender, "!controller");
         Rule memory currentRule = rulesByPod[_podId];
         require(currentRule.contractAddress != address(0), "No rule set");
 

--- a/contracts/SafeTeller.sol
+++ b/contracts/SafeTeller.sol
@@ -13,6 +13,8 @@ contract SafeTeller {
     string public functionSigExecTransaction =
         "execTransaction(address,uint256,bytes,uint8,uint256,uint256,uint256,address,address,bytes)";
 
+    address controller;
+
     struct Action {
         address to;
         uint256 value;
@@ -24,11 +26,21 @@ contract SafeTeller {
     event CreateSafe(uint256 indexed podId, address safeAddress);
     event UpdateAction(uint256 _podId, address _to, uint256 _value, bytes _data);
     event ActionExecuted(bool success, bytes result);
+
+    constructor() {
+        controller = msg.sender;
+    }
+
+    function updateController(address _controller) public {
+        require(controller == msg.sender, "!controller");
+        controller = _controller;
+    }
     
     function createSafe(uint256 _podId)
         public
         returns(address safeAddres)
     {
+        require(controller == msg.sender, "!controller");
         bytes memory data = "";
         address[] memory ownerArray = new address[](1);
         ownerArray[0] = address(this);
@@ -63,6 +75,7 @@ contract SafeTeller {
     }
 
     function createPendingAction(uint256 _podId, address _to, uint256 _value, bytes memory _data) public {
+        require(controller == msg.sender, "!controller");
         actionProposalByPod[_podId] = Action({
             to : _to,
             value : _value,
@@ -75,6 +88,7 @@ contract SafeTeller {
         uint _podId,
         address _safeAddress
     ) public {
+        require(controller == msg.sender, "!controller");
         uint8 operation = uint8(0);
         uint256 safeTxGas = uint256(0);
         uint256 baseGas = uint256(0);
@@ -112,7 +126,7 @@ contract SafeTeller {
     }
 
     function bytesToAddress(bytes memory bys)
-        public
+        internal
         pure
         returns (address addr)
     {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "lint": "solhint contracts/**/*.sol",
     "prettier": "prettier --write contracts/**/*.sol",
-    "test": " hardhat test",
+    "test": "hardhat test",
     "compile": " hardhat compile"
   },
   "husky": {

--- a/test/orca.js
+++ b/test/orca.js
@@ -62,6 +62,11 @@ describe("Orca Tests", () => {
       ruleManager.address,
       safeTeller.address,
     ]);
+
+    await powerBank.connect(admin).updateController(orcaProtocol.address);
+    await ruleManager.connect(admin).updateController(orcaProtocol.address);
+    await voteManager.connect(admin).updateController(orcaProtocol.address);
+    await safeTeller.connect(admin).updateController(orcaProtocol.address);
   });
 
   it("should create a pod", async () => {
@@ -110,7 +115,7 @@ describe("Orca Tests", () => {
     expect(voteProposal.approveVotes).to.equal(0);
     expect(voteProposal.rejectVotes).to.equal(0);
 
-    await expect(voteManager.connect(host).vote(1, true))
+    await expect(orcaProtocol.connect(host).vote(1, true, { gasLimit: "9500000" }))
       .to.emit(voteManager, "CastVote")
       .withArgs(1, 1, host.address, true);
 
@@ -120,11 +125,11 @@ describe("Orca Tests", () => {
   });
 
   it("should cast a duplicate vote and revert", async () => {
-    await expect(voteManager.connect(host).vote(1, true)).to.be.revertedWith("This member has already voted");
+    await expect(orcaProtocol.connect(host).vote(1, true)).to.be.revertedWith("This member has already voted");
   });
 
   it("should fail to finalize vote due to voting period", async () => {
-    await expect(voteManager.connect(host).finalizeProposal(1, { gasLimit: "9500000" })).to.be.revertedWith(
+    await expect(orcaProtocol.connect(host).finalizeProposal(1, { gasLimit: "9500000" })).to.be.revertedWith(
       "The voting period has not ended",
     );
   });
@@ -174,7 +179,7 @@ describe("Orca Tests", () => {
     expect(voteProposal.approveVotes).to.equal(0);
     expect(voteProposal.rejectVotes).to.equal(0);
 
-    await expect(voteManager.connect(host).vote(1, true))
+    await expect(orcaProtocol.connect(host).vote(1, true))
       .to.emit(voteManager, "CastVote")
       .withArgs(1, 2, host.address, true);
 

--- a/test/powerBank.js
+++ b/test/powerBank.js
@@ -2,8 +2,8 @@ const { expect, use } = require("chai");
 const { waffle, ethers } = require("hardhat");
 
 const OrcaProtocol = require("../artifacts/contracts/OrcaProtocol.sol/OrcaProtocol.json");
-const PowerBank = require("../artifacts/contracts/PowerBank.sol/PowerBank.json");
 const PowerToken = require("../artifacts/contracts/PowerBank.sol/PowerToken.json");
+const PowerBank = require("../artifacts/contracts/PowerBank.sol/PowerBank.json");
 const OrcaToken = require("../artifacts/contracts/OrcaToken.sol/OrcaToken.json");
 const VoteManager = require("../artifacts/contracts/VoteManager.sol/VoteManager.json");
 
@@ -18,7 +18,10 @@ const totalSupply = 10;
 use(solidity);
 
 describe("PowerBank unit tests", () => {
-  const [admin, member1, member2] = provider.getWallets();
+  // IMPORTANT: for some reason using account[0] fails to deploy when running the full test suite
+  // potentially out of gas? or something to do with Alchemy infra, need to revisit.
+  // it seems like there is some state/artifact carryover between tests.
+  const [, admin, member1, member2] = provider.getWallets();
 
   it("should deploy contracts", async () => {
     // podManager = await deployContract(admin, PowerBank);


### PR DESCRIPTION
Locked down access for all state changing functions across the contracts so they can only be accessed through `OrcaProtocol` this allows Orca to act as the single source of truth for coordinating sub-functions, and will allow us to upgrade business logic much more cleanly. 

I used `require(controller == msg.sender, "!controller");` in all controller functions instead of abstracting into a modifier because according to Yearn it's bad to abstract away critical safety logic.

